### PR TITLE
Fix bower install reported errors

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-    "name": "Angular.uuid2",
+    "name": "angular.uuid2",
     "version": "0.0.1",
-    "main": "dist/angular-uuid2.min.js",
+    "main": "dist/angular-uuid2.js",
     "homepage": "https://github.com/MBehtemam/angular-uuid",
     "version":"0.0.1"
 }


### PR DESCRIPTION
bower install recommends lowercase naming, and minified files should not be main.
